### PR TITLE
Add s.team

### DIFF
--- a/open-in-app/services.json
+++ b/open-in-app/services.json
@@ -4,7 +4,8 @@
       "links": [
          "store.steampowered.com",
          "steamcommunity.com",
-         "help.steampowered.com"
+         "help.steampowered.com",
+         "s.team"
       ],
       "identifier": "steam://openurl/"
    },


### PR DESCRIPTION
S.team is Steam's link shortener for some links like friend links
(Example is in the "add friends" tab in steam)